### PR TITLE
Fix for #138

### DIFF
--- a/install_prereq.sh
+++ b/install_prereq.sh
@@ -6,6 +6,10 @@ sudo apt-get update
 sudo apt-get upgrade -y
 sudo apt-get install -y dnsmasq hostapd screen curl python3-pip python3-setuptools python3-wheel mosquitto haveged net-tools
 
-sudo pip3 install paho-mqtt pyaes tornado
-
+PYVERSION=$(python3 -c 'import sys; print(".".join(map(str, sys.version_info[:3])))'|cut -f 1,2 -d \.)
+    if (( $(echo "$PYVERSION < 3.7" | bc -l) )); then
+      sudo pip3 install paho-mqtt pyaes tornado
+    else
+      sudo python3 -m pip install paho-mqtt pyaes tornado
+    fi
 echo "Ready to start upgrade"


### PR DESCRIPTION
Python3 from 3.7 on manages pip installs a little differently. This change should handle this change.
*NOTE: I can't recall where I saw that this is the preferred 3.7 method. I can't cite. However things work better now for me. See #138 as well.